### PR TITLE
Add isolated Cloudflare PGP directory worker

### DIFF
--- a/.github/workflows/cloudflare-pgp-worker.yml
+++ b/.github/workflows/cloudflare-pgp-worker.yml
@@ -1,0 +1,79 @@
+name: Cloudflare PGP Worker
+
+on:
+  pull_request:
+    paths:
+      - "workers/pgp-directory/**"
+      - ".github/workflows/cloudflare-pgp-worker.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "workers/pgp-directory/**"
+      - ".github/workflows/cloudflare-pgp-worker.yml"
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: "Deploy to Cloudflare workers.dev"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-pgp-worker-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: workers/pgp-directory
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: workers/pgp-directory/package.json
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Test
+        run: npm run check
+
+      - name: Wrangler dry run
+        run: npm run deploy:dry-run
+
+  deploy:
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: cloudflare-preview
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: workers/pgp-directory/package.json
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Deploy workers.dev preview
+        run: npm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/workers/pgp-directory/README.md
+++ b/workers/pgp-directory/README.md
@@ -1,0 +1,65 @@
+# cy8er PGP Directory Worker
+
+Isolierter Cloudflare Worker für den öffentlichen PGP-Schlüssel von `cy8er@djjessejay.ch`.
+
+## Endpunkte
+
+- `/health` — Healthcheck ohne Ausgabe des Schlüssels
+- `/pgp.txt` — ASCII-armored Public Key
+- `/cy8er.djjessejay.ch.asc` — ASCII-armored Public Key
+- `/.well-known/openpgpkey/*` — absichtlich deaktiviert, bis WKD-Hashing und binärer Export validiert sind
+
+## Lokal prüfen
+
+```bash
+cd workers/pgp-directory
+npm install --ignore-scripts
+npm run check
+npm run deploy:dry-run
+```
+
+## Cloudflare Dashboard
+
+1. Worker `cy8er-pgp-directory` anlegen oder den ersten manuellen Workflow-Deploy ausführen.
+2. In **Settings → Variables and Secrets** `PUBLIC_PGP_KEY` als verschlüsseltes Secret setzen.
+3. Den vollständigen ASCII-armored Public Key einfügen; niemals den Private Key.
+4. `DEPLOYMENT_ENV=preview` belassen, bis die workers.dev-Adresse geprüft wurde.
+5. Noch keine produktive Custom Domain oder Route setzen.
+
+## GitHub Environment
+
+Environment `cloudflare-preview` anlegen und folgende Repository- oder Environment-Secrets setzen:
+
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_API_TOKEN`
+
+Das API-Token erhält nur die minimal erforderlichen Worker-Script-Rechte für das Zielkonto.
+
+## Deployment
+
+Der Workflow validiert Pull Requests automatisch. Deployments erfolgen ausschließlich manuell:
+
+1. GitHub Actions öffnen.
+2. Workflow **Cloudflare PGP Worker** auswählen.
+3. **Run workflow** starten.
+4. Eingabe `deploy=true` setzen.
+5. Nach dem Deploy `/health` prüfen.
+6. Erst anschließend den Public-Key-Endpunkt prüfen.
+
+## Healthcheck
+
+```bash
+curl --fail --silent --show-error \
+  https://cy8er-pgp-directory.<workers-subdomain>.workers.dev/health | jq
+```
+
+Die Antwort muss `status: ok` und `keyConfigured: true` enthalten.
+
+## Rollback
+
+1. Cloudflare Dashboard → Worker → Deployments öffnen.
+2. Letzte bekannte stabile Version auswählen.
+3. Rollback/erneutes Deployment dieser Version ausführen.
+4. `/health` und `/pgp.txt` erneut prüfen.
+
+Keine produktive Route freigeben, bevor Rollback und Schlüsselabruf getestet wurden.

--- a/workers/pgp-directory/package.json
+++ b/workers/pgp-directory/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@djjessejay/pgp-directory-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "node --check src/index.js && node --test",
+    "test": "node --test",
+    "deploy": "wrangler deploy",
+    "deploy:dry-run": "wrangler deploy --dry-run --outdir dist",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "wrangler": "^4.24.3"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/workers/pgp-directory/src/index.js
+++ b/workers/pgp-directory/src/index.js
@@ -1,0 +1,126 @@
+const KEY_PATHS = new Set([
+  "/pgp.txt",
+  "/cy8er.djjessejay.ch.asc",
+]);
+
+const BASE_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
+  "Referrer-Policy": "no-referrer",
+  "X-Content-Type-Options": "nosniff",
+};
+
+function jsonResponse(payload, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(payload, null, 2), {
+    status,
+    headers: {
+      ...BASE_HEADERS,
+      "Cache-Control": "no-store",
+      "Content-Type": "application/json; charset=utf-8",
+      ...extraHeaders,
+    },
+  });
+}
+
+function configuredPublicKey(env) {
+  const value = typeof env.PUBLIC_PGP_KEY === "string"
+    ? env.PUBLIC_PGP_KEY.trim()
+    : "";
+
+  if (!value.includes("-----BEGIN PGP PUBLIC KEY BLOCK-----")) {
+    return null;
+  }
+
+  return `${value}\n`;
+}
+
+function headAwareResponse(request, body, init) {
+  return new Response(request.method === "HEAD" ? null : body, init);
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const requestId = crypto.randomUUID();
+    const publicKey = configuredPublicKey(env);
+
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return jsonResponse(
+        { error: "method_not_allowed", requestId },
+        405,
+        { Allow: "GET, HEAD" },
+      );
+    }
+
+    if (url.pathname === "/health") {
+      return headAwareResponse(
+        request,
+        JSON.stringify({
+          status: "ok",
+          service: "cy8er-pgp-directory",
+          environment: env.DEPLOYMENT_ENV || "unknown",
+          keyConfigured: Boolean(publicKey),
+          requestId,
+        }, null, 2),
+        {
+          status: 200,
+          headers: {
+            ...BASE_HEADERS,
+            "Cache-Control": "no-store",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        },
+      );
+    }
+
+    if (url.pathname === "/") {
+      return headAwareResponse(
+        request,
+        JSON.stringify({
+          service: "cy8er-pgp-directory",
+          status: publicKey ? "ready" : "configuration_required",
+          endpoints: ["/health", ...KEY_PATHS],
+          requestId,
+        }, null, 2),
+        {
+          status: publicKey ? 200 : 503,
+          headers: {
+            ...BASE_HEADERS,
+            "Cache-Control": "no-store",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        },
+      );
+    }
+
+    if (KEY_PATHS.has(url.pathname)) {
+      if (!publicKey) {
+        return jsonResponse({
+          error: "public_key_not_configured",
+          requestId,
+        }, 503);
+      }
+
+      return headAwareResponse(request, publicKey, {
+        status: 200,
+        headers: {
+          ...BASE_HEADERS,
+          "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+          "Content-Disposition": "inline; filename=\"cy8er.djjessejay.ch.asc\"",
+          "Content-Type": "application/pgp-keys; charset=utf-8",
+          ETag: `W/\"${publicKey.length}\"`,
+        },
+      });
+    }
+
+    if (url.pathname.startsWith("/.well-known/openpgpkey/")) {
+      return jsonResponse({
+        error: "wkd_not_enabled",
+        detail: "Enable only after canonical WKD hashing and binary key export are validated.",
+        requestId,
+      }, 501);
+    }
+
+    return jsonResponse({ error: "not_found", requestId }, 404);
+  },
+};

--- a/workers/pgp-directory/test/worker.test.js
+++ b/workers/pgp-directory/test/worker.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import worker from "../src/index.js";
+
+const envWithoutKey = { DEPLOYMENT_ENV: "test" };
+const envWithKey = {
+  DEPLOYMENT_ENV: "test",
+  PUBLIC_PGP_KEY: "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: test\n\nZmFrZQ==\n-----END PGP PUBLIC KEY BLOCK-----",
+};
+
+test("health endpoint reports configuration state", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.test/health"),
+    envWithoutKey,
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.status, "ok");
+  assert.equal(body.keyConfigured, false);
+});
+
+test("root remains unavailable until a public key is configured", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.test/"),
+    envWithoutKey,
+  );
+  assert.equal(response.status, 503);
+});
+
+test("public key endpoint serves the configured key", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.test/cy8er.djjessejay.ch.asc"),
+    envWithKey,
+  );
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type"), /application\/pgp-keys/);
+  assert.match(await response.text(), /BEGIN PGP PUBLIC KEY BLOCK/);
+});
+
+test("HEAD requests do not return a body", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.test/pgp.txt", { method: "HEAD" }),
+    envWithKey,
+  );
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "");
+});
+
+test("unsafe methods are rejected", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.test/pgp.txt", { method: "POST" }),
+    envWithKey,
+  );
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get("allow"), "GET, HEAD");
+});
+
+test("WKD remains explicitly disabled", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.test/.well-known/openpgpkey/hu/example"),
+    envWithKey,
+  );
+  assert.equal(response.status, 501);
+});

--- a/workers/pgp-directory/wrangler.jsonc
+++ b/workers/pgp-directory/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "cy8er-pgp-directory",
+  "main": "src/index.js",
+  "compatibility_date": "2026-07-14",
+  "workers_dev": true,
+  "preview_urls": true,
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  },
+  "vars": {
+    "DEPLOYMENT_ENV": "preview"
+  }
+}


### PR DESCRIPTION
## Was geändert wurde

- isolierter Cloudflare Worker unter `workers/pgp-directory/`
- Healthcheck unter `/health`
- öffentliche Schlüssel-Endpunkte `/pgp.txt` und `/cy8er.djjessejay.ch.asc`
- `PUBLIC_PGP_KEY` ausschließlich als Cloudflare Secret
- WKD-Endpunkte bewusst deaktiviert, bis Hashing und binärer Key-Export validiert sind
- Node-Test-Suite für Routing, HEAD, Methoden und Konfigurationszustand
- Wrangler Dry-Run in CI
- manuell gegatetes Deployment über das GitHub Environment `cloudflare-preview`
- Dashboard-, Healthcheck- und Rollback-Dokumentation

## Sicherheitsmodell

- keine Produktionsroute
- kein Private Key im Repository
- kein automatisches Deployment bei Push oder Pull Request
- minimale GitHub-Workflow-Berechtigungen
- Deployment nur über `workflow_dispatch` mit `deploy=true`
- Cloudflare-Secrets müssen separat konfiguriert werden

## Noch erforderlich

1. GitHub Environment `cloudflare-preview` anlegen.
2. `CLOUDFLARE_ACCOUNT_ID` und ein minimal berechtigtes `CLOUDFLARE_API_TOKEN` setzen.
3. Im Cloudflare Worker `PUBLIC_PGP_KEY` mit dem vollständigen öffentlichen ASCII-Key setzen.
4. Workflow manuell ausführen und `workers.dev` testen.
5. Erst nach erfolgreichem Rollback-Test eine Custom Domain oder Route konfigurieren.

## Validierung

Die Laufzeit- und Dry-Run-Prüfung wird durch den neuen GitHub-Actions-Workflow durchgeführt. Ein lokaler Clone-Test aus der Agent-Umgebung war nicht möglich, da der Container keine DNS-Auflösung zu GitHub hatte.