### PR TITLE
Add social-share preview image, canonical link, explicit favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,15 @@
     <meta property="og:title" content="DJ Jesse Jay - Zürich">
     <meta property="og:description" content="Professioneller DJ aus Zürich seit 1997. Progressiv, House, Techno. Radiosendung 'The Blue Dimension' auf Radio LoRa.">
     <meta property="og:url" content="https://djjessejay.ch">
+    <link rel="canonical" href="https://djjessejay.ch/">
+    <meta property="og:image" content="https://djjessejay.ch/DJ-Jesse-Jay.jpg">
+    <meta property="og:image:alt" content="DJ Jesse Jay">
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary">
+    <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="DJ Jesse Jay - Zürich">
     <meta name="twitter:description" content="Professioneller DJ aus Zürich seit 1997. Progressiv, House, Techno. Radiosendung 'The Blue Dimension' auf Radio LoRa.">
+    <meta name="twitter:image" content="https://djjessejay.ch/DJ-Jesse-Jay.jpg">
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
     <!-- Content Security Policy -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://api.anthropic.com https://www.google.com/recaptcha/; img-src 'self' data:; frame-src https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/">
     <!-- Google reCAPTCHA v3 -->


### PR DESCRIPTION
## Summary
- `og:image` / `twitter:image` now point at `DJ-Jesse-Jay.jpg` so link previews (Slack, WhatsApp, Discord, etc.) show the profile photo instead of nothing. `twitter:card` upgraded to `summary_large_image` to match.
- Added a `canonical` link tag (`djjessejay.ch`) — the site is reachable from both the `github.io` URL and the custom domain, so this avoids duplicate-content ambiguity for search engines.
- Added an explicit `<link rel="icon">` for `favicon.ico`; previously relied entirely on browser default-path discovery.

## Verification
- Verified `index.html` still parses cleanly and the inline `<script>` block passes `node --check` after the head changes.
- Purely `<head>` metadata additions — no visual/layout changes to verify beyond that.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AyLeh3hYkvQRiY4xnuByKG)_