### PR TITLE
Harden Cloudflare deployment environment

### DIFF
--- a/.github/workflows/cloudflare-pgp-worker.yml
+++ b/.github/workflows/cloudflare-pgp-worker.yml
@@ -54,7 +54,10 @@ jobs:
         run: npm run deploy:dry-run
 
   deploy:
-    if: github.event_name == 'workflow_dispatch' && inputs.deploy
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.deploy &&
+      github.ref == 'refs/heads/main'
     needs: validate
     runs-on: ubuntu-latest
     environment: cloudflare-preview
@@ -71,6 +74,16 @@ jobs:
 
       - name: Install dependencies
         run: npm install --ignore-scripts
+
+      - name: Verify deployment credentials
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          test -n "$CLOUDFLARE_API_TOKEN"
+          test -n "$CLOUDFLARE_ACCOUNT_ID"
 
       - name: Deploy workers.dev preview
         run: npm run deploy

--- a/workers/pgp-directory/README.md
+++ b/workers/pgp-directory/README.md
@@ -28,12 +28,32 @@ npm run deploy:dry-run
 
 ## GitHub Environment
 
-Environment `cloudflare-preview` anlegen und folgende Repository- oder Environment-Secrets setzen:
+Environment `cloudflare-preview` unter **Settings → Environments** anlegen und wie folgt schützen:
 
-- `CLOUDFLARE_ACCOUNT_ID`
-- `CLOUDFLARE_API_TOKEN`
+1. Unter **Required reviewers** mindestens einen Reviewer mit Repository-Lesezugriff eintragen.
+2. Optional **Prevent self-review** aktivieren, sofern ein zweiter berechtigter Reviewer verfügbar ist.
+3. Unter **Deployment branches and tags** die Option **Selected branches and tags** wählen.
+4. Als einzige Branch-Regel `main` eintragen.
+5. Folgende Environment-Secrets setzen:
+   - `CLOUDFLARE_ACCOUNT_ID`
+   - `CLOUDFLARE_API_TOKEN`
 
-Das API-Token erhält nur die minimal erforderlichen Worker-Script-Rechte für das Zielkonto.
+Der Workflow enthält zusätzlich eine technische Sperre auf `refs/heads/main`. Environment-Branch-Regel und Workflow-Gate müssen beide erfüllt sein.
+
+## Cloudflare API-Token
+
+Ein benutzerdefiniertes Cloudflare API-Token erstellen. Kein Global API Key und keine Kombination aus E-Mail plus Global API Key verwenden.
+
+Erforderliche Berechtigungen:
+
+- **Account → Workers Scripts → Edit**
+- **Account → Account Settings → Read**
+
+Ressourcenbereich:
+
+- ausschließlich das Cloudflare-Konto, in dem `cy8er-pgp-directory` betrieben wird
+
+Das Token nicht als Repository-Variable, Klartextdatei oder `wrangler.jsonc` speichern. Es wird ausschließlich als GitHub Environment Secret `CLOUDFLARE_API_TOKEN` hinterlegt.
 
 ## Deployment
 
@@ -41,10 +61,14 @@ Der Workflow validiert Pull Requests automatisch. Deployments erfolgen ausschlie
 
 1. GitHub Actions öffnen.
 2. Workflow **Cloudflare PGP Worker** auswählen.
-3. **Run workflow** starten.
-4. Eingabe `deploy=true` setzen.
-5. Nach dem Deploy `/health` prüfen.
-6. Erst anschließend den Public-Key-Endpunkt prüfen.
+3. Branch `main` auswählen.
+4. **Run workflow** starten.
+5. Eingabe `deploy=true` setzen.
+6. Required-Reviewer-Freigabe erteilen.
+7. Nach dem Deploy `/health` prüfen.
+8. Erst anschließend den Public-Key-Endpunkt prüfen.
+
+Ein manueller Start von einem anderen Branch führt nicht zum Deploy-Job.
 
 ## Healthcheck
 


### PR DESCRIPTION
## Änderungen

- Deploy-Job zusätzlich auf `refs/heads/main` begrenzt
- explizite Prüfung auf vorhandene Cloudflare-Credentials vor dem Deploy
- Required-Reviewer- und Deployment-Branch-Policy für `cloudflare-preview` dokumentiert
- minimale Cloudflare-Token-Rechte dokumentiert: Workers Scripts Edit und Account Settings Read
- Global API Key ausdrücklich ausgeschlossen

## Noch im Dashboard erforderlich

Die GitHub- und Cloudflare-Admin-Einstellungen können über den verbundenen Connector nicht gesetzt werden:

1. `cloudflare-preview` → Required reviewers aktivieren
2. Deployment branches and tags → Selected branches and tags → `main`
3. benutzerdefiniertes Cloudflare API-Token mit minimalem Account-Scope erstellen
4. Token als Environment Secret `CLOUDFLARE_API_TOKEN` speichern

## Sicherheit

Environment-Branch-Regel und Workflow-Gate ergänzen sich. Selbst wenn die Environment-Regel versehentlich gelockert wird, deployt der Workflow nicht von einem anderen Ref.