### PR TITLE
fix: add secure distributed render farm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,16 @@
     "dev": "webpack --mode development --watch",
     "build:css": "tailwindcss -i ./src/input.css -o ./tailwind.css --minify",
     "watch:css": "tailwindcss -i ./src/input.css -o ./tailwind.css --watch",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --check render-farm/render-farm-master.js && python3 -m py_compile render-farm/render-worker.py",
+    "render:master": "node render-farm/render-farm-master.js"
   },
-  "keywords": ["dj", "vanilla", "javascript", "tailwind", "express"],
+  "keywords": [
+    "dj",
+    "vanilla",
+    "javascript",
+    "tailwind",
+    "express"
+  ],
   "author": "Marcel Raschke",
   "license": "MIT",
   "repository": {
@@ -23,7 +30,8 @@
   },
   "dependencies": {
     "express": "^5.2.1",
-    "nodemailer": "^9.0.1"
+    "nodemailer": "^9.0.1",
+    "ws": "^8.21.0"
   },
   "overrides": {
     "http-proxy-middleware": "^3.0.7",

--- a/render-farm/README.md
+++ b/render-farm/README.md
@@ -1,0 +1,23 @@
+# M3•0N Render Farm
+
+## Master
+
+```bash
+npm install ws
+export RENDER_TOKEN='replace-with-a-long-random-token'
+export AUDIO_FILE=/path/to/audio.wav   # optional
+node render-farm-master.js
+```
+
+## Worker
+
+```bash
+pip install websocket-client
+export RENDER_TOKEN='same-token-as-master'
+export MAIN_URL='ws://MASTER_HOST:8081'
+export MASTER_HTTP='http://MASTER_HOST:8081'
+export BLEND_FILE=/path/to/synaptic_garden.blend
+python3 render-worker.py
+```
+
+Use a VPN/private network or TLS reverse proxy for production. Do not expose the plain `ws://` endpoint directly to the Internet.

--- a/render-farm/render-farm-master.js
+++ b/render-farm/render-farm-master.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const { spawn } = require("child_process");
+const WebSocket = require("ws");
+
+const PORT = Number(process.env.PORT || 8081);
+const TOKEN = process.env.RENDER_TOKEN;
+const TOTAL_FRAMES = Number(process.env.TOTAL_FRAMES || 3600);
+const CHUNK_SIZE = Number(process.env.CHUNK_SIZE || 60);
+const LEASE_MS = Number(process.env.LEASE_MS || 10 * 60 * 1000);
+const ROOT = path.resolve(process.env.FRAME_DIR || "./frames");
+const OUTPUT = path.resolve(process.env.OUTPUT || "./output/Synaptic_Garden_Tech_Dancer.mp4");
+const AUDIO = process.env.AUDIO_FILE ? path.resolve(process.env.AUDIO_FILE) : null;
+
+if (!TOKEN) throw new Error("Set RENDER_TOKEN before starting the master");
+fs.mkdirSync(ROOT, { recursive: true });
+fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+
+const tasks = new Map();
+for (let start = 1; start <= TOTAL_FRAMES; start += CHUNK_SIZE) {
+  const end = Math.min(start + CHUNK_SIZE - 1, TOTAL_FRAMES);
+  tasks.set(`${start}-${end}`, { start, end, state: "queued", worker: null, leaseUntil: 0 });
+}
+
+function authorized(req) {
+  return req.headers.authorization === `Bearer ${TOKEN}`;
+}
+function framePath(n) { return path.join(ROOT, `frame_${String(n).padStart(4, "0")}.png`); }
+function taskFor(start, end) { return tasks.get(`${start}-${end}`); }
+function nextTask(worker) {
+  const now = Date.now();
+  for (const task of tasks.values()) {
+    if (task.state === "queued" || (task.state === "running" && task.leaseUntil < now)) {
+      task.state = "running"; task.worker = worker; task.leaseUntil = now + LEASE_MS; return task;
+    }
+  }
+  return null;
+}
+function allComplete() { return [...tasks.values()].every(t => t.state === "completed"); }
+function framesPresent(task) {
+  for (let n = task.start; n <= task.end; n++) if (!fs.existsSync(framePath(n))) return false;
+  return true;
+}
+function renderVideo() {
+  const args = ["-y", "-framerate", "60", "-start_number", "1", "-i", path.join(ROOT, "frame_%04d.png")];
+  if (AUDIO) args.push("-i", AUDIO);
+  args.push("-c:v", "libx264", "-pix_fmt", "yuv420p");
+  if (AUDIO) args.push("-c:a", "aac", "-shortest");
+  args.push(OUTPUT);
+  const child = spawn("ffmpeg", args, { stdio: "inherit" });
+  child.on("close", code => {
+    if (code !== 0) return console.error(`FFmpeg failed with exit code ${code}`);
+    const hash = crypto.createHash("sha256").update(fs.readFileSync(OUTPUT)).digest("hex");
+    fs.writeFileSync(`${OUTPUT}.sha256`, `${hash}  ${path.basename(OUTPUT)}\n`);
+    console.log(`Rendered: ${OUTPUT}\nSHA-256: ${hash}`);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (!authorized(req)) { res.writeHead(401); return res.end("Unauthorized\n"); }
+  const match = req.url.match(/^\/frames\/(\d+)$/);
+  if (req.method !== "PUT" || !match) { res.writeHead(404); return res.end("Not found\n"); }
+  const n = Number(match[1]);
+  if (n < 1 || n > TOTAL_FRAMES) { res.writeHead(400); return res.end("Invalid frame\n"); }
+  const tmp = `${framePath(n)}.${crypto.randomUUID()}.tmp`;
+  const out = fs.createWriteStream(tmp);
+  req.pipe(out);
+  out.on("finish", () => { fs.renameSync(tmp, framePath(n)); res.writeHead(201); res.end("stored\n"); });
+  out.on("error", err => { try { fs.unlinkSync(tmp); } catch {} res.writeHead(500); res.end(`${err}\n`); });
+});
+
+const wss = new WebSocket.Server({ noServer: true, maxPayload: 1024 * 1024 });
+server.on("upgrade", (req, socket, head) => {
+  if (!authorized(req)) return socket.destroy();
+  wss.handleUpgrade(req, socket, head, ws => wss.emit("connection", ws, req));
+});
+wss.on("connection", ws => {
+  const worker = crypto.randomUUID();
+  ws.on("message", raw => {
+    let data; try { data = JSON.parse(raw); } catch { return ws.close(1003, "Invalid JSON"); }
+    if (data.type === "READY_FOR_TASK") {
+      const task = nextTask(worker);
+      ws.send(JSON.stringify(task ? { type: "RENDER_CHUNK", ...task } : { type: allComplete() ? "ALL_TASKS_COMPLETED" : "WAIT" }));
+    } else if (data.type === "CHUNK_COMPLETED") {
+      const task = taskFor(Number(data.startFrame), Number(data.endFrame));
+      if (!task || task.worker !== worker || !framesPresent(task)) return ws.close(1008, "Invalid task completion");
+      task.state = "completed"; task.leaseUntil = 0;
+      console.log(`Completed ${task.start}-${task.end} by ${worker}`);
+      if (allComplete()) renderVideo();
+    }
+  });
+});
+server.listen(PORT, "0.0.0.0", () => console.log(`Render master listening on ${PORT}`));

--- a/render-farm/render-worker.py
+++ b/render-farm/render-worker.py
@@ -1,0 +1,32 @@
+import json, os, subprocess, tempfile
+from pathlib import Path
+from urllib.request import Request, urlopen
+import websocket
+
+MAIN_URL = os.environ.get("MAIN_URL", "ws://127.0.0.1:8081")
+MASTER_HTTP = os.environ.get("MASTER_HTTP", MAIN_URL.replace("ws://", "http://").replace("wss://", "https://"))
+TOKEN = os.environ["RENDER_TOKEN"]
+BLEND = os.environ.get("BLEND_FILE", "synaptic_garden.blend")
+
+def upload(frame, filename):
+    req = Request(f"{MASTER_HTTP}/frames/{frame}", data=Path(filename).read_bytes(), method="PUT", headers={"Authorization": f"Bearer {TOKEN}", "Content-Type": "image/png"})
+    with urlopen(req, timeout=120) as response:
+        if response.status not in (200, 201): raise RuntimeError(f"upload failed: {response.status}")
+
+def on_message(ws, raw):
+    data = json.loads(raw)
+    if data["type"] == "WAIT": ws.send(json.dumps({"type": "READY_FOR_TASK"})); return
+    if data["type"] != "RENDER_CHUNK": return
+    start, end = data["start"], data["end"]
+    with tempfile.TemporaryDirectory(prefix="m3on-render-") as directory:
+        prefix = str(Path(directory) / "frame_")
+        cmd = ["blender", "-b", BLEND, "-s", str(start), "-e", str(end), "-o", prefix, "-F", "PNG", "-a"]
+        result = subprocess.run(cmd, check=False)
+        if result.returncode != 0: raise RuntimeError(f"Blender failed: {result.returncode}")
+        for frame in range(start, end + 1): upload(frame, f"{prefix}{frame:04d}.png")
+    ws.send(json.dumps({"type": "CHUNK_COMPLETED", "startFrame": start, "endFrame": end}))
+    ws.send(json.dumps({"type": "READY_FOR_TASK"}))
+
+def on_open(ws): ws.send(json.dumps({"type": "READY_FOR_TASK"}))
+headers = [f"Authorization: Bearer {TOKEN}"]
+websocket.WebSocketApp(MAIN_URL, header=headers, on_open=on_open, on_message=on_message).run_forever()


### PR DESCRIPTION
Adds the corrected M3•0N render-farm dispatcher and worker with authenticated WebSocket tasks, leases, centralized frame uploads, render error handling, audio muxing, and SHA-256 output proof. Syntax checks pass locally.