### PR TITLE
fix(static.yml): correct cleanup logic to preserve essential deployment files

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,8 +42,10 @@ jobs:
           rm -f *.swf
           # Remove old HTML versions (not needed for deploy)
           rm -f home.html home.htm
-          # Remove documentation, configs, build files
-          rm -rf .github web_scraper presskit.zip *.md CONTRIBUTING.md CODE_OF_CONDUCT.md LICENSE
+          # Remove web scraper utility (not site content)
+          rm -rf web_scraper
+          # Remove markdown docs and license (not served, just metadata)
+          rm -f *.md CONTRIBUTING.md CODE_OF_CONDUCT.md LICENSE
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

Corrects overly aggressive cleanup in static.yml that was removing essential files needed for the deployment artifact.

## Changes

**Previous approach** removed:
- presskit.zip (should be kept as downloadable asset)
- .github directory (typically excluded from artifact anyway)
- Too aggressive with markdown files

**Corrected approach** removes only:
- Database dumps (*.sql, *.xml) — historical archives, not site content
- Video files (*.mov, *.mp4, *.webm) — large legacy assets
- Flash files (*.swf) — non-functional
- Legacy HTML versions (home.html, home.htm) — not deployed
- web_scraper/ — utility directory, not site content
- Markdown docs (*.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE) — metadata only

**Keeps:**
- presskit.zip (download asset)
- .github/ (workflow configs, excluded from artifact anyway)
- All HTML, CSS, JS, and image assets

## Root Cause Analysis

The previous deployment cancellation (run #30571764877) failed because:
1. Initial attempt uploaded too much (entire repo with .git, all archives)
2. Cleanup was then overly aggressive, potentially removing needed resources
3. This PR finds the correct balance — remove size-heavy legacy files while keeping deployment essentials

## Testing

1. CI checks should pass
2. Merge to main will trigger static.yml
3. Verify deployment completes with `conclusion: success` (not `cancelled`)
4. Check site loads correctly and presskit.zip is downloadable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyLeh3hYkvQRiY4xnuByKG)_