### PR TITLE
feat(pgp-directory): security headers, rate limiting, optional health auth

### DIFF
--- a/workers/pgp-directory/README.md
+++ b/workers/pgp-directory/README.md
@@ -9,6 +9,37 @@ Isolierter Cloudflare Worker für den öffentlichen PGP-Schlüssel von `cy8er@dj
 - `/cy8er.djjessejay.ch.asc` — ASCII-armored Public Key
 - `/.well-known/openpgpkey/*` — absichtlich deaktiviert, bis WKD-Hashing und binärer Export validiert sind
 
+## Neue Funktionen
+
+### Sicherheits-Header
+
+Alle Antworten enthalten folgende Sicherheits-Header:
+
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` (HSTS)
+- `Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()`
+- `X-Robots-Tag: noindex, nofollow`
+
+Zusätzlich zu den bestehenden Headern (`Content-Security-Policy`, `Referrer-Policy`, `X-Content-Type-Options`, `Access-Control-Allow-Origin`).
+
+### Rate Limiting
+
+- **Limit**: 60 Anfragen pro Minute pro Client-IP.
+- **Header** auf jeder Antwort:
+  - `X-RateLimit-Limit: 60`
+  - `X-RateLimit-Remaining: <verbleibende Anfragen>`
+  - `X-RateLimit-Reset: <Unix-Zeitstempel>`
+- Bei Überschreitung: `429 Too Many Requests` mit `Retry-After`-Header.
+- Der Limiter ist prozessintern (in-memory). Cloudflare-Worker-Isolate werden unregelmäßig recycelt, daher ist das Limit ein Best-Effort-Schutz und keine strikte Garantie. Für harte Limits Cloudflare-Rate-Limiting-Regeln im Dashboard verwenden.
+
+### Authentifizierung für `/health` (optional)
+
+- **Mechanismus**: Bearer-Token-Authentifizierung.
+- **Umgebungsvariable**: `HEALTH_AUTH_TOKEN` (als **Secret** in Cloudflare oder GitHub setzen).
+- **Verhalten**:
+  - Ist `HEALTH_AUTH_TOKEN` **nicht gesetzt**, ist `/health` öffentlich erreichbar.
+  - Ist `HEALTH_AUTH_TOKEN` **gesetzt**, erfordert `/health` den Header `Authorization: Bearer <token>`.
+  - Bei fehlendem/ungültigem Token: `401 Unauthorized` mit `WWW-Authenticate: Bearer`.
+
 ## Lokal prüfen
 
 ```bash
@@ -24,7 +55,8 @@ npm run deploy:dry-run
 2. In **Settings → Variables and Secrets** `PUBLIC_PGP_KEY` als verschlüsseltes Secret setzen.
 3. Den vollständigen ASCII-armored Public Key einfügen; niemals den Private Key.
 4. `DEPLOYMENT_ENV=preview` belassen, bis die workers.dev-Adresse geprüft wurde.
-5. Noch keine produktive Custom Domain oder Route setzen.
+5. Optional `HEALTH_AUTH_TOKEN` als Secret setzen, um `/health` hinter eine Bearer-Token-Authentifizierung zu stellen.
+6. Noch keine produktive Custom Domain oder Route setzen.
 
 ## GitHub Environment `cloudflare-preview`
 
@@ -88,6 +120,8 @@ Der Deploy-Job enthält zusätzlich zur Environment-Branch-Regel einen Code-Guar
 curl --fail --silent --show-error \
   https://cy8er-pgp-directory.<workers-subdomain>.workers.dev/health | jq
 ```
+
+Ist `HEALTH_AUTH_TOKEN` gesetzt, zusätzlich `-H "Authorization: Bearer <token>"` anhängen.
 
 Die Antwort muss `status: ok` und `keyConfigured: true` enthalten.
 

--- a/workers/pgp-directory/src/index.js
+++ b/workers/pgp-directory/src/index.js
@@ -7,8 +7,17 @@ const BASE_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
   "Referrer-Policy": "no-referrer",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "Permissions-Policy":
+    "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
   "X-Content-Type-Options": "nosniff",
+  "X-Robots-Tag": "noindex, nofollow",
 };
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 60;
+
+const rateBuckets = new Map();
 
 function jsonResponse(payload, status = 200, extraHeaders = {}) {
   return new Response(JSON.stringify(payload, null, 2), {
@@ -38,6 +47,80 @@ function headAwareResponse(request, body, init) {
   return new Response(request.method === "HEAD" ? null : body, init);
 }
 
+function clientIp(request) {
+  const cfIp = request.headers.get("cf-connecting-ip");
+  if (cfIp) return cfIp.trim();
+
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim();
+
+  return "unknown";
+}
+
+function checkRateLimit(ip, now = Date.now()) {
+  const windowStart = Math.floor(now / RATE_LIMIT_WINDOW_MS) * RATE_LIMIT_WINDOW_MS;
+  const reset = Math.floor((windowStart + RATE_LIMIT_WINDOW_MS) / 1000);
+  const key = `${ip}:${windowStart}`;
+
+  for (const bucketKey of rateBuckets.keys()) {
+    const separator = bucketKey.lastIndexOf(":");
+    const bucketIp = bucketKey.slice(0, separator);
+    const bucketWindow = Number(bucketKey.slice(separator + 1));
+    if (bucketIp === ip && bucketWindow + RATE_LIMIT_WINDOW_MS <= now) {
+      rateBuckets.delete(bucketKey);
+    }
+  }
+
+  const current = rateBuckets.get(key) || 0;
+
+  if (current >= RATE_LIMIT_MAX_REQUESTS) {
+    return {
+      limited: true,
+      remaining: 0,
+      limit: RATE_LIMIT_MAX_REQUESTS,
+      reset,
+      retryAfter: Math.max(1, reset - Math.floor(now / 1000)),
+    };
+  }
+
+  rateBuckets.set(key, current + 1);
+
+  return {
+    limited: false,
+    remaining: RATE_LIMIT_MAX_REQUESTS - current - 1,
+    limit: RATE_LIMIT_MAX_REQUESTS,
+    reset,
+  };
+}
+
+function rateLimitHeaders(state) {
+  return {
+    "X-RateLimit-Limit": String(state.limit),
+    "X-RateLimit-Remaining": String(state.remaining),
+    "X-RateLimit-Reset": String(state.reset),
+  };
+}
+
+function checkHealthAuth(request, env) {
+  const expected = typeof env.HEALTH_AUTH_TOKEN === "string"
+    ? env.HEALTH_AUTH_TOKEN.trim()
+    : "";
+
+  if (!expected) {
+    return { ok: true };
+  }
+
+  const header = request.headers.get("authorization") || "";
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  const provided = match ? match[1].trim() : "";
+
+  if (provided.length !== expected.length) {
+    return { ok: false };
+  }
+
+  return { ok: provided === expected };
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -52,7 +135,34 @@ export default {
       );
     }
 
+    const ip = clientIp(request);
+    const rateState = checkRateLimit(ip);
+
+    if (rateState.limited) {
+      return jsonResponse(
+        {
+          error: "rate_limit_exceeded",
+          detail: "Too many requests. Please retry later.",
+          requestId,
+        },
+        429,
+        {
+          ...rateLimitHeaders(rateState),
+          "Retry-After": String(rateState.retryAfter),
+        },
+      );
+    }
+
     if (url.pathname === "/health") {
+      const auth = checkHealthAuth(request, env);
+      if (!auth.ok) {
+        return jsonResponse(
+          { error: "unauthorized", requestId },
+          401,
+          { "WWW-Authenticate": "Bearer" },
+        );
+      }
+
       return headAwareResponse(
         request,
         JSON.stringify({
@@ -66,6 +176,7 @@ export default {
           status: 200,
           headers: {
             ...BASE_HEADERS,
+            ...rateLimitHeaders(rateState),
             "Cache-Control": "no-store",
             "Content-Type": "application/json; charset=utf-8",
           },
@@ -86,6 +197,7 @@ export default {
           status: publicKey ? 200 : 503,
           headers: {
             ...BASE_HEADERS,
+            ...rateLimitHeaders(rateState),
             "Cache-Control": "no-store",
             "Content-Type": "application/json; charset=utf-8",
           },
@@ -98,17 +210,18 @@ export default {
         return jsonResponse({
           error: "public_key_not_configured",
           requestId,
-        }, 503);
+        }, 503, rateLimitHeaders(rateState));
       }
 
       return headAwareResponse(request, publicKey, {
         status: 200,
         headers: {
           ...BASE_HEADERS,
+          ...rateLimitHeaders(rateState),
           "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
           "Content-Disposition": "inline; filename=\"cy8er.djjessejay.ch.asc\"",
           "Content-Type": "application/pgp-keys; charset=utf-8",
-          ETag: `W/\"${publicKey.length}\"`,
+          ETag: `W/"${publicKey.length}"`,
         },
       });
     }
@@ -118,9 +231,13 @@ export default {
         error: "wkd_not_enabled",
         detail: "Enable only after canonical WKD hashing and binary key export are validated.",
         requestId,
-      }, 501);
+      }, 501, rateLimitHeaders(rateState));
     }
 
-    return jsonResponse({ error: "not_found", requestId }, 404);
+    return jsonResponse(
+      { error: "not_found", requestId },
+      404,
+      rateLimitHeaders(rateState),
+    );
   },
 };

--- a/workers/pgp-directory/test/worker.test.js
+++ b/workers/pgp-directory/test/worker.test.js
@@ -7,10 +7,20 @@ const envWithKey = {
   DEPLOYMENT_ENV: "test",
   PUBLIC_PGP_KEY: "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: test\n\nZmFrZQ==\n-----END PGP PUBLIC KEY BLOCK-----",
 };
+const envWithHealthToken = {
+  ...envWithKey,
+  HEALTH_AUTH_TOKEN: "test-secret-token",
+};
+
+function requestWithIp(url, init, ip = "203.0.113.7") {
+  const req = new Request(url, init);
+  req.headers.set("cf-connecting-ip", ip);
+  return req;
+}
 
 test("health endpoint reports configuration state", async () => {
   const response = await worker.fetch(
-    new Request("https://example.test/health"),
+    requestWithIp("https://example.test/health"),
     envWithoutKey,
   );
   assert.equal(response.status, 200);
@@ -21,7 +31,7 @@ test("health endpoint reports configuration state", async () => {
 
 test("root remains unavailable until a public key is configured", async () => {
   const response = await worker.fetch(
-    new Request("https://example.test/"),
+    requestWithIp("https://example.test/"),
     envWithoutKey,
   );
   assert.equal(response.status, 503);
@@ -29,7 +39,7 @@ test("root remains unavailable until a public key is configured", async () => {
 
 test("public key endpoint serves the configured key", async () => {
   const response = await worker.fetch(
-    new Request("https://example.test/cy8er.djjessejay.ch.asc"),
+    requestWithIp("https://example.test/cy8er.djjessejay.ch.asc"),
     envWithKey,
   );
   assert.equal(response.status, 200);
@@ -39,7 +49,7 @@ test("public key endpoint serves the configured key", async () => {
 
 test("HEAD requests do not return a body", async () => {
   const response = await worker.fetch(
-    new Request("https://example.test/pgp.txt", { method: "HEAD" }),
+    requestWithIp("https://example.test/pgp.txt", { method: "HEAD" }),
     envWithKey,
   );
   assert.equal(response.status, 200);
@@ -48,7 +58,7 @@ test("HEAD requests do not return a body", async () => {
 
 test("unsafe methods are rejected", async () => {
   const response = await worker.fetch(
-    new Request("https://example.test/pgp.txt", { method: "POST" }),
+    requestWithIp("https://example.test/pgp.txt", { method: "POST" }),
     envWithKey,
   );
   assert.equal(response.status, 405);
@@ -57,8 +67,117 @@ test("unsafe methods are rejected", async () => {
 
 test("WKD remains explicitly disabled", async () => {
   const response = await worker.fetch(
-    new Request("https://example.test/.well-known/openpgpkey/hu/example"),
+    requestWithIp("https://example.test/.well-known/openpgpkey/hu/example"),
     envWithKey,
   );
   assert.equal(response.status, 501);
+});
+
+test("security headers are present on responses", async () => {
+  const response = await worker.fetch(
+    requestWithIp("https://example.test/health"),
+    envWithoutKey,
+  );
+  assert.equal(response.headers.get("strict-transport-security"), "max-age=31536000; includeSubDomains; preload");
+  assert.match(response.headers.get("permissions-policy"), /geolocation=\(\)/);
+  assert.match(response.headers.get("permissions-policy"), /camera=\(\)/);
+  assert.equal(response.headers.get("x-robots-tag"), "noindex, nofollow");
+  assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+  assert.equal(response.headers.get("referrer-policy"), "no-referrer");
+});
+
+test("rate limit headers are exposed while under the limit", async () => {
+  const response = await worker.fetch(
+    requestWithIp("https://example.test/health"),
+    envWithoutKey,
+  );
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("x-ratelimit-limit"), "60");
+  const remaining = Number(response.headers.get("x-ratelimit-remaining"));
+  assert.ok(remaining >= 0 && remaining < 60, "remaining must be within valid range");
+  const reset = Number(response.headers.get("x-ratelimit-reset"));
+  assert.ok(reset > 0, "reset must be a positive unix timestamp");
+});
+
+test("rate limiting returns 429 once the limit is exceeded", async () => {
+  const ip = "198.51.100.42";
+  let lastResponse;
+  for (let i = 0; i < 61; i += 1) {
+    lastResponse = await worker.fetch(
+      requestWithIp("https://example.test/health", {}, ip),
+      envWithoutKey,
+    );
+  }
+  assert.equal(lastResponse.status, 429);
+  const body = await lastResponse.json();
+  assert.equal(body.error, "rate_limit_exceeded");
+  assert.equal(lastResponse.headers.get("x-ratelimit-remaining"), "0");
+  const retryAfter = Number(lastResponse.headers.get("retry-after"));
+  assert.ok(retryAfter >= 1, "Retry-After must be at least 1 second");
+});
+
+test("rate limiting is independent per client IP", async () => {
+  const ipA = "198.51.100.1";
+  const ipB = "198.51.100.2";
+  for (let i = 0; i < 61; i += 1) {
+    await worker.fetch(requestWithIp("https://example.test/health", {}, ipA), envWithoutKey);
+  }
+  const blocked = await worker.fetch(
+    requestWithIp("https://example.test/health", {}, ipA),
+    envWithoutKey,
+  );
+  assert.equal(blocked.status, 429);
+  const otherIp = await worker.fetch(
+    requestWithIp("https://example.test/health", {}, ipB),
+    envWithoutKey,
+  );
+  assert.equal(otherIp.status, 200);
+});
+
+test("health endpoint is public when HEALTH_AUTH_TOKEN is not set", async () => {
+  const response = await worker.fetch(
+    requestWithIp("https://example.test/health"),
+    envWithKey,
+  );
+  assert.equal(response.status, 200);
+});
+
+test("health endpoint rejects requests without a bearer token when configured", async () => {
+  const response = await worker.fetch(
+    requestWithIp("https://example.test/health"),
+    envWithHealthToken,
+  );
+  assert.equal(response.status, 401);
+  assert.equal(response.headers.get("www-authenticate"), "Bearer");
+  const body = await response.json();
+  assert.equal(body.error, "unauthorized");
+});
+
+test("health endpoint accepts a valid bearer token", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.test/health", {
+      headers: {
+        "cf-connecting-ip": "203.0.113.9",
+        authorization: "Bearer test-secret-token",
+      },
+    }),
+    envWithHealthToken,
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.status, "ok");
+});
+
+test("health endpoint rejects an invalid bearer token", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.test/health", {
+      headers: {
+        "cf-connecting-ip": "203.0.113.10",
+        authorization: "Bearer wrong-token",
+      },
+    }),
+    envWithHealthToken,
+  );
+  assert.equal(response.status, 401);
+  assert.equal(response.headers.get("www-authenticate"), "Bearer");
 });


### PR DESCRIPTION
## Summary

Hardens the `cy8er-pgp-directory` Cloudflare Worker with security headers, rate limiting, and optional authentication for the `/health` endpoint.

### 1. Enhanced security headers
Added to all responses:
- `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` (HSTS)
- `Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()`
- `X-Robots-Tag: noindex, nofollow`

### 2. Rate limiting
- **Limit**: 60 requests per minute per client IP (in-memory, fixed window)
- **Headers**: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` on every response
- Returns `429 Too Many Requests` with `Retry-After` when exceeded
- IP derived from `cf-connecting-ip` (falls back to `x-forwarded-for`)

### 3. Optional `/health` authentication
- Bearer token auth gated behind the `HEALTH_AUTH_TOKEN` env var
- If unset → `/health` stays public (default behavior unchanged)
- If set → requires `Authorization: Bearer <token>`, otherwise `401` with `WWW-Authenticate: Bearer`
- Comparison guarded by a length check to avoid naive short-circuit leakage

## Files modified
- `workers/pgp-directory/src/index.js` — new headers, limiter, auth check, and helpers
- `workers/pgp-directory/test/worker.test.js` — 8 new tests (14 total)
- `workers/pgp-directory/README.md` — documented new features and `HEALTH_AUTH_TOKEN` secret

## Verification
```bash
cd workers/pgp-directory
npm run check
```
Result: `node --check` passes and all 14 tests pass (`# pass 14`, `# fail 0`).

## Notes
- The in-memory limiter is best-effort: Cloudflare recycles Worker isolates unpredictably, so the per-IP cap is a soft protection, not a hard guarantee. For strict limits, use Cloudflare Rate Limiting rules in the dashboard.
- `HEALTH_AUTH_TOKEN` should be set as a **secret** (Cloudflare Dashboard → Settings → Variables and Secrets, or GitHub environment secret). No `wrangler.jsonc` change is needed.
- `wrangler.jsonc` is intentionally unchanged — `HEALTH_AUTH_TOKEN` is a runtime secret, not a plaintext var.

## Next steps
1. Set `HEALTH_AUTH_TOKEN` as a secret if `/health` should be protected (optional).
2. Deploy via the manual GitHub Actions workflow with `deploy=true`.
3. Verify `/health` (with/without token), rate limiting (>60 requests from one IP), and security headers.

