### PR TITLE
feat(deploy): switch to custom server + Cloudflare proxy (Option 2)

### DIFF
--- a/DNS_CONFIG.md
+++ b/DNS_CONFIG.md
@@ -1,21 +1,24 @@
 # DNS Configuration for djjessejay.ch
 
-This document contains the authoritative DNS zone configuration for the djjessejay.ch domain, configured for GitHub Pages deployment with Cloudflare DNS.
+This document contains the authoritative DNS zone configuration for the djjessejay.ch domain, configured for **Cloudflare Proxy with custom server** (IPv4 + IPv6 support).
 
 ## Domain Overview
 
 - **Domain**: djjessejay.ch
 - **DNS Provider**: Cloudflare
-- **Hosting**: GitHub Pages
-- **Last Updated**: 17.07.2026
+- **Hosting**: Custom Server (IPv4: `185.101.158.113`, IPv6: `2001:1680:101:8bd::1`)
+- **CDN/Proxy**: Cloudflare (DDoS protection, caching, SSL termination)
+- **Last Updated**: 08.08.2025
 
 ## Important Notes
 
-1. **GitHub Pages with Custom Apex Domain**: When using a custom apex domain (root domain) with GitHub Pages, you MUST use A records pointing to GitHub's IP addresses. You cannot use a CNAME record for the apex domain.
+1. **Cloudflare Proxy**: The A record (IPv4) is **proxied** (orange cloud) for DDoS protection, caching, and SSL termination. The AAAA record (IPv6) must remain **DNS only** (gray cloud) due to Cloudflare limitations.
 
-2. **CNAME File**: The repository should NOT contain a CNAME file when using an apex domain. The CNAME file is only used when deploying to a subdomain (e.g., username.github.io).
+2. **IPv6 Support**: Cloudflare automatically routes IPv6 traffic through its own IPv6 network when the A record is proxied, even if the AAAA record is DNS only. Visitors on IPv6 will still benefit from Cloudflare's infrastructure.
 
-3. **HTTPS**: GitHub Pages automatically provisions and renews TLS certificates for custom domains. Ensure "Enforce HTTPS" is enabled in your GitHub Pages settings.
+3. **SSL**: Cloudflare Universal SSL is used for all proxied records (automatically provisioned).
+
+4. **GitHub Pages**: **Disabled** for this domain. Static files are served directly from the custom server.
 
 ---
 
@@ -24,12 +27,12 @@ This document contains the authoritative DNS zone configuration for the djjessej
 ### SOA Record (Start of Authority)
 
 ```
-djjessejay.ch. 3600 IN SOA aarav.ns.cloudflare.com. dns.cloudflare.com. 2053592236 10000 2400 604800 3600
+djjessejay.ch. 3600 IN SOA aarav.ns.cloudflare.com. dns.cloudflare.com. 2053592237 10000 2400 604800 3600
 ```
 
 - **Primary Name Server**: aarav.ns.cloudflare.com.
 - **Responsible Email**: dns.cloudflare.com. (admin contact)
-- **Serial Number**: 2053592236 (timestamp: 2026-07-17)
+- **Serial Number**: 2053592237 (timestamp: 2025-08-08)
 - **Refresh**: 10000 seconds (2 hours 46 minutes)
 - **Retry**: 2400 seconds (40 minutes)
 - **Expire**: 604800 seconds (7 days)
@@ -44,55 +47,56 @@ djjessejay.ch. 86400 IN NS rosalyn.ns.cloudflare.com.
 
 Both name servers must be configured in your domain registrar's settings to point to Cloudflare.
 
-### A Records (Address Records for Apex Domain)
+### A Record (Address Record for Apex Domain, IPv4)
 
-These A records point the root domain to GitHub Pages' IP addresses:
+This A record points the root domain to the custom server's IPv4 address. It is **proxied** through Cloudflare (orange cloud):
 
 ```
-djjessejay.ch. 3600 IN A 185.199.108.153
-djjessejay.ch. 3600 IN A 185.199.109.153
-djjessejay.ch. 3600 IN A 185.199.110.153
-djjessejay.ch. 3600 IN A 185.199.111.153
+djjessejay.ch. 3600 IN A 185.101.158.113   ; Proxied (orange cloud)
 ```
 
-**Note**: All four IP addresses are required for proper GitHub Pages functionality and redundancy.
+**Note**: Only the single server IPv4 address is required. Cloudflare proxying provides DDoS protection, caching, and SSL termination. The origin server must accept traffic from [Cloudflare's IP ranges](https://www.cloudflare.com/ips/).
+
+### AAAA Record (Address Record for Apex Domain, IPv6)
+
+This AAAA record points the root domain to the custom server's IPv6 address. It must remain **DNS only** (gray cloud) due to Cloudflare limitations on proxied AAAA records at the apex:
+
+```
+djjessejay.ch. 3600 IN AAAA 2001:1680:101:8bd::1   ; DNS only (gray cloud)
+```
+
+**Note**: Because the A record is proxied, Cloudflare automatically serves IPv6 visitors through its own IPv6 network. The DNS-only AAAA record ensures direct IPv6 reachability to the origin as a fallback.
 
 ### CNAME Record (Subdomain)
 
-The www subdomain points to the apex domain:
+The www subdomain points to the apex domain (proxied):
 
 ```
-www.djjessejay.ch. 3600 IN CNAME djjessejay.ch.
+www.djjessejay.ch. 3600 IN CNAME djjessejay.ch.   ; Proxied (orange cloud)
 ```
 
-This ensures that visitors accessing `www.djjessejay.ch` are served the same content as `djjessejay.ch`.
-
-### TXT Record (GitHub Pages Verification)
-
-```
-_github-pages-challenge-marcelraschke.djjessejay.ch. 3600 IN TXT "60e5f988c1da04523b99e4208c1726"
-```
-
-This TXT record is required for GitHub Pages to verify domain ownership. The challenge token is unique to this domain and repository.
+This ensures that visitors accessing `www.djjessejay.ch` are served the same content as `djjessejay.ch`, with Cloudflare protection applied.
 
 ---
 
-## GitHub Pages Configuration
+## Server Configuration
 
-### Repository Settings
+### Origin Server (Custom Server)
 
-1. Navigate to: **Settings → Pages**
-2. **Source**: Deploy from branch `main` / `root` folder
-3. **Custom domain**: `djjessejay.ch`
-4. **Enforce HTTPS**: ✅ Enabled (recommended)
+The origin server hosts the static files for djjessejay.ch and must be reachable on both IPv4 (`185.101.158.113`) and IPv6 (`2001:1680:101:8bd::1`).
+
+- **Web server**: nginx or equivalent serving the static site from the deployment root
+- **TLS**: A valid certificate is required for Cloudflare's **Full (Strict)** SSL mode. Use Let's Encrypt (or an equivalent CA) for the origin certificate, covering both `djjessejay.ch` and `www.djjessejay.ch`.
+- **Firewall**: Restrict HTTP/HTTPS inbound to Cloudflare's IP ranges (IPv4 and IPv6) plus your own administrative access. Direct origin access by other clients should be blocked.
+- **Deploy**: See `deploy.sh` for the deployment workflow to this server.
 
 ### Verification Steps
 
 1. Add the DNS records above to your Cloudflare DNS settings
-2. Wait for DNS propagation (typically 1-4 hours with Cloudflare)
-3. In GitHub Pages settings, enter `djjessejay.ch` as the custom domain
-4. GitHub will automatically verify the domain using the TXT record
-5. Once verified, HTTPS certificate will be provisioned automatically
+2. Ensure the A record is **proxied** (orange cloud) and the AAAA record is **DNS only** (gray cloud)
+3. Wait for DNS propagation (typically 1–4 hours with Cloudflare)
+4. Confirm the origin server is serving the site over HTTPS with a valid certificate
+5. Verify `https://djjessejay.ch` loads through Cloudflare and the SSL/TLS mode is **Full (Strict)**
 
 ---
 
@@ -104,7 +108,8 @@ This TXT record is required for GitHub Pages to verify domain ownership. The cha
 2. Select the `djjessejay.ch` domain
 3. Navigate to **DNS → Records**
 4. Add all records from the zone file above
-5. Ensure the Cloudflare proxy (orange cloud icon) is **disabled** for all GitHub Pages records (DNS only)
+5. Set the A record proxy to **Proxied** (orange cloud)
+6. Set the AAAA record proxy to **DNS only** (gray cloud)
 
 ### SSL/TLS Settings
 
@@ -113,11 +118,18 @@ This TXT record is required for GitHub Pages to verify domain ownership. The cha
 - **HTTP/2**: On
 - **HTTP/3 (QUIC)**: On
 - **TLS 1.3**: Enabled
+- **Minimum TLS Version**: 1.2
 
 ### Caching Settings
 
 - **Caching Level**: Standard
 - **Browser Cache TTL**: 1 year (recommended for static assets)
+- **Always Online**: On (serves cached content if the origin is unreachable)
+
+### Origin Server (for Full Strict SSL)
+
+- Install a valid origin certificate (e.g., Let's Encrypt) covering `djjessejay.ch` and `www.djjessejay.ch`
+- Alternatively, use a Cloudflare Origin CA certificate (valid only for Cloudflare-proxied traffic)
 
 ---
 
@@ -129,24 +141,31 @@ This TXT record is required for GitHub Pages to verify domain ownership. The cha
 - Verify all records are correctly entered in Cloudflare
 - Ensure name servers at registrar point to Cloudflare
 
-### GitHub Pages Not Loading
+### Site Not Loading Through Cloudflare
 
-1. Verify all four A records are present
-2. Check that the CNAME file has been removed from the repository
-3. Ensure custom domain is correctly set in GitHub Pages settings
-4. Wait up to 24 hours for GitHub to provision the SSL certificate
+1. Confirm the A record is **proxied** (orange cloud) in Cloudflare
+2. Verify the origin server is reachable on `185.101.158.113` (IPv4) and `2001:1680:101:8bd::1` (IPv6)
+3. Check the origin firewall allows Cloudflare's IP ranges
+4. Confirm the origin TLS certificate is valid (required for Full Strict SSL)
+5. Review Cloudflare analytics for error responses (5xx) from the origin
 
 ### Mixed Content Warnings
 
 - Ensure all links in your HTML use HTTPS
 - Check that no resources are loaded over HTTP
-- Use protocol-relative URLs (//example.com) or absolute HTTPS URLs
+- Use protocol-relative URLs (`//example.com`) or absolute HTTPS URLs
 
 ### SSL Certificate Issues
 
-- GitHub Pages automatically provisions Let's Encrypt certificates
-- If certificate provisioning fails, remove and re-add the custom domain
-- Ensure DNS records are correct before adding the custom domain
+- Cloudflare Universal SSL is provisioned automatically for proxied records
+- If the origin certificate is invalid, Cloudflare will return a 525/526 error — renew the origin certificate
+- For Full (Strict) SSL, the origin certificate must be issued by a recognized CA or Cloudflare Origin CA
+
+### IPv6 Connectivity Issues
+
+- Confirm the AAAA record (`2001:1680:101:8bd::1`) is present and **DNS only**
+- IPv6 visitors are primarily served by Cloudflare's IPv6 network when the A record is proxied
+- If direct IPv6 origin access fails, verify the origin server listens on IPv6 and the firewall permits it
 
 ---
 
@@ -155,14 +174,14 @@ This TXT record is required for GitHub Pages to verify domain ownership. The cha
 ### Verify DNS Records
 
 ```bash
-# Check A records
+# Check A record (proxied — returns Cloudflare IPs)
 dig djjessejay.ch A +short
+
+# Check AAAA record (DNS only — returns origin IPv6)
+dig djjessejay.ch AAAA +short
 
 # Check CNAME record
 dig www.djjessejay.ch CNAME +short
-
-# Check TXT record
-dig _github-pages-challenge-marcelraschke.djjessejay.ch TXT +short
 
 # Check NS records
 dig djjessejay.ch NS +short
@@ -171,31 +190,48 @@ dig djjessejay.ch NS +short
 ### Expected Results
 
 ```
-# A records should return:
-185.199.108.153
-185.199.109.153
-185.199.110.153
-185.199.111.153
+# A record (proxied) returns Cloudflare IPv4 ranges, e.g.:
+104.21.x.x
+172.67.x.x
+
+# AAAA record (DNS only) returns the origin IPv6:
+2001:1680:101:8bd::1
 
 # CNAME should return:
 djjessejay.ch.
-
-# TXT should return:
-"60e5f988c1da04523b99e4208c1726"
 
 # NS should return:
 aarav.ns.cloudflare.com.
 rosalyn.ns.cloudflare.com.
 ```
 
+### Verify Origin Reachability
+
+```bash
+# Direct IPv4 origin (bypass Cloudflare)
+curl -k --resolve djjessejay.ch:443:185.101.158.113 https://djjessejay.ch/
+
+# Direct IPv6 origin (bypass Cloudflare)
+curl -k --resolve djjessejay.ch:443:[2001:1680:101:8bd::1] https://djjessejay.ch/
+```
+
+### Verify Cloudflare Proxying
+
+```bash
+# Should return Cloudflare headers (cf-ray, server: cloudflare)
+curl -I https://djjessejay.ch/
+```
+
 ---
 
 ## References
 
-- [GitHub Pages Custom Domains](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site)
 - [Cloudflare DNS Documentation](https://developers.cloudflare.com/dns/)
-- [GitHub Pages A Records](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain)
+- [Cloudflare Proxy / Orange Cloud](https://developers.cloudflare.com/fundamentals/get-started/concepts/proxy/)
+- [Cloudflare SSL/TLS Modes](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/)
+- [Cloudflare IP Ranges](https://www.cloudflare.com/ips/)
+- [Let's Encrypt](https://letsencrypt.org/)
 
 ---
 
-*This file was generated on 2026-07-17 and should be updated whenever DNS changes are made.*
+*This file was generated on 2025-08-08 and should be updated whenever DNS changes are made.*

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,17 +1,89 @@
 #!/usr/bin/env bash
-# Static site — no build step. This ensures the GitHub Pages custom domain
-# file exists and pushes the current branch; actual deployment happens via
-# static.yml once this branch is merged into main.
+# Deploy djjessejay.ch to the custom origin server (Option 2: custom server + Cloudflare proxy).
+#
+# Builds the static site, prunes large/legacy files, and syncs the result to the
+# origin server via rsync over SSH. Cloudflare (proxied A record) serves the site
+# to visitors with DDoS protection, caching and SSL termination.
+#
+# Required environment variables:
+#   DEPLOY_USER   SSH user on the origin server
+#   DEPLOY_HOST   Origin server hostname or IP (default: 185.101.158.113)
+#   DEPLOY_PATH   Document root on the origin server
+#
+# Optional environment variables:
+#   DEPLOY_PORT   SSH port (default: 22)
+#   SSH_KEY        Path to a private SSH key (default: agent / ~/.ssh)
+#   RSYNC_DELETE   Set to "1" to delete remote files not present locally (default: 1)
+#
+# Usage:
+#   DEPLOY_USER=deploy DEPLOY_PATH=/var/www/djjessejay.ch ./deploy.sh
 set -euo pipefail
 cd "$(dirname "$0")"
 
-if [ ! -f CNAME ] || [ "$(cat CNAME)" != "djjessejay.ch" ]; then
-    echo "djjessejay.ch" > CNAME
-    git add CNAME
-    git commit -s -m "Add CNAME for djjessejay.ch custom domain" -- CNAME
+# --- Configuration ----------------------------------------------------------
+DEPLOY_HOST="${DEPLOY_HOST:-185.101.158.113}"
+DEPLOY_PORT="${DEPLOY_PORT:-22}"
+RSYNC_DELETE="${RSYNC_DELETE:-1}"
+SSH_KEY="${SSH_KEY:-}"
+
+: "${DEPLOY_USER:?DEPLOY_USER is required (SSH user on the origin server)}"
+: "${DEPLOY_PATH:?DEPLOY_PATH is required (document root on the origin server)}"
+
+# --- Build CSS (Tailwind) ---------------------------------------------------
+if [ -f package.json ] && node -e "process.exit(('build:css' in (require('./package.json').scripts||{})) ? 0 : 1)"; then
+    echo "→ Building CSS with Tailwind"
+    npm run build:css
 fi
 
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-git push -u origin "$BRANCH"
+# --- Staging directory ------------------------------------------------------
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
 
-echo "Pushed '$BRANCH'. Merge the PR into main to trigger the static.yml GitHub Pages deploy."
+echo "→ Staging site in $STAGE"
+rsync -a --exclude='.git/' --exclude='node_modules/' \
+    --exclude='.github/' --exclude='.env' --exclude='.env.*' \
+    ./ "$STAGE/"
+
+# --- Prune large / legacy files (mirrors static.yml) ------------------------
+echo "→ Pruning large and legacy files"
+# Database dumps (SQL/XML archives)
+rm -f "$STAGE"/*.sql "$STAGE"/*.xml
+# Video files (large legacy assets)
+rm -f "$STAGE"/*.mov "$STAGE"/*.mp4 "$STAGE"/*.webm
+# Flash files (non-functional)
+rm -f "$STAGE"/*.swf
+# Old HTML versions (not needed for deploy)
+rm -f "$STAGE"/home.html "$STAGE"/home.htm
+# Web scraper utility (not site content)
+rm -rf "$STAGE"/web_scraper
+# Markdown docs and license (not served, just metadata)
+rm -f "$STAGE"/*.md "$STAGE"/CONTRIBUTING.md "$STAGE"/CODE_OF_CONDUCT.md "$STAGE"/LICENSE
+# Legacy files
+rm -f "$STAGE"/michi.swf "$STAGE"/get_flashplayer_88_31.gif
+# Deployment artefacts (never served)
+rm -f "$STAGE"/deploy.sh "$STAGE"/verify_dns.sh
+
+# The CNAME file is a GitHub Pages artefact and must not be deployed to the
+# custom server — remove it if it was checked in.
+rm -f "$STAGE"/CNAME
+
+# --- rsync to origin --------------------------------------------------------
+SSH_OPTS=(-p "$DEPLOY_PORT")
+if [ -n "$SSH_KEY" ]; then
+    SSH_OPTS+=(-i "$SSH_KEY")
+fi
+SSH_OPTS+=( -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 )
+
+DELETE_FLAG="--delete"
+if [ "$RSYNC_DELETE" != "1" ]; then
+    DELETE_FLAG=""
+fi
+
+echo "→ Syncing to ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH} (port ${DEPLOY_PORT})"
+rsync -az --checksum $DELETE_FLAG \
+    -e "ssh ${SSH_OPTS[*]}" \
+    "$STAGE/" "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/"
+
+echo "✓ Deployed to ${DEPLOY_HOST}:${DEPLOY_PATH}"
+echo "  Cloudflare (proxied) serves visitors from this origin."
+echo "  Verify: https://djjessejay.ch/"


### PR DESCRIPTION
## Summary
- **DNS_CONFIG.md**: Switched the authoritative DNS documentation from GitHub Pages to **Option 2 (custom server + Cloudflare proxy)**.
  - Replaced the four GitHub Pages A records (`185.199.108–111.153`) with a single **proxied** A record (`185.101.158.113`, orange cloud).
  - Added a **DNS-only** AAAA record (`2001:1680:101:8bd::1`, gray cloud).
  - Removed the GitHub Pages TXT verification record and the GitHub Pages configuration section.
  - Added a Server Configuration section (origin TLS, firewall, deploy.sh reference) and updated Cloudflare settings (Full Strict SSL, Always Online), Troubleshooting, and Testing sections for origin + proxy verification.
- **deploy.sh**: Replaced the GitHub Pages deployment (CNAME + branch push) with **rsync-over-SSH deployment to the custom origin server**.
  - Builds CSS (`npm run build:css`, auto-detected via `package.json`).
  - Prunes large/legacy files before sync (mirrors `static.yml`), and removes the `CNAME` artefact.
  - Configurable via `DEPLOY_USER`, `DEPLOY_HOST` (default `185.101.158.113`), `DEPLOY_PATH`, `DEPLOY_PORT`, `SSH_KEY`, `RSYNC_DELETE`.
  - Hardened with `set -euo pipefail`, `mktemp` staging with `trap` cleanup, and `StrictHostKeyChecking=accept-new`.

## Verification
- `bash -n deploy.sh` — syntax OK (shellcheck not installable in sandbox).
- `build:css` auto-detection validated against `package.json` scripts.
- Cross-checked origin IP (`185.101.158.113`) consistency between `deploy.sh` and `DNS_CONFIG.md`.
- Confirmed no GitHub Pages artefacts remain (only the explicit "GitHub Pages: Disabled" note in DNS_CONFIG.md).

## Usage
```bash
DEPLOY_USER=deploy DEPLOY_PATH=/var/www/djjessejay.ch ./deploy.sh
# optional: DEPLOY_PORT=22 SSH_KEY=~/.ssh/id_ed25519
```

## Note
`.github/workflows/static.yml` still deploys to GitHub Pages on `main` pushes. With Option 2 active, that workflow should be disabled/removed in a follow-up to avoid deploying to the unused Pages target.
